### PR TITLE
feat: add existingSecret option for data

### DIFF
--- a/chart/ssh-punchhole/Chart.yaml
+++ b/chart/ssh-punchhole/Chart.yaml
@@ -4,6 +4,6 @@ description: Tiny SSH based reverse-tunnel to expose services behind a firewall
 
 type: application
 
-version: 0.0.4
+version: 0.0.5
 
 appVersion: "v2.3"

--- a/chart/ssh-punchhole/README.md
+++ b/chart/ssh-punchhole/README.md
@@ -58,10 +58,11 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### SSH Credentials
 
-| Name              | Description                                                                         | Value |
-| ----------------- | ----------------------------------------------------------------------------------- | ----- |
-| `data.privateKey` | Passwordless OpenSSH Private Key authorized to login as `SSH_USER` on `REMOTE_HOST` | `""`  |
-| `data.knownHosts` | Used for OpenSSH HostKeyVerification. Output of `ssh-keyscan ${REMOTE_HOST}`.       | `""`  |
+| Name                  | Description                                                                         | Value |
+| --------------------- | ----------------------------------------------------------------------------------- | ----- |
+| `data.privateKey`     | Passwordless OpenSSH Private Key authorized to login as `SSH_USER` on `REMOTE_HOST` | `""`  |
+| `data.knownHosts`     | Used for OpenSSH HostKeyVerification. Output of `ssh-keyscan ${REMOTE_HOST}`.       | `""`  |
+| `data.existingSecret` | Name of secret containing keys `id_rsa` and `known_hosts`.                          | `""`  |
 
 
 ## License

--- a/chart/ssh-punchhole/templates/deployment.yaml
+++ b/chart/ssh-punchhole/templates/deployment.yaml
@@ -80,5 +80,9 @@ spec:
       - name: ssh-data
         secret:
           defaultMode: 0600
+          {{- if not $.Values.data.existingSecret }}
           secretName: {{ include "charts.fullname" $ }}-data
+          {{- else }}
+          secretName: {{ $.Values.data.existingSecret }}
+          {{- end }}
 {{- end }}

--- a/chart/ssh-punchhole/templates/secret.yaml
+++ b/chart/ssh-punchhole/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not $.Values.data.existingSecret }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -8,3 +9,4 @@ metadata:
 data:
   id_rsa: {{ required "data.privateKey is required" .Values.data.privateKey | b64enc | quote }}
   known_hosts: {{ required "data.knownHosts is required" .Values.data.knownHosts | b64enc | quote }}
+{{- end }}

--- a/chart/ssh-punchhole/values.yaml
+++ b/chart/ssh-punchhole/values.yaml
@@ -60,6 +60,7 @@ configuration:
 data:
   privateKey: ""
   knownHosts: ""
+  existingSecret: ""
 
 podSecurityContext:
   fsGroup: 65534

--- a/chart/ssh-punchhole/values.yaml
+++ b/chart/ssh-punchhole/values.yaml
@@ -57,7 +57,7 @@ configuration:
 ## @section SSH Credentials
 ## @param data.privateKey Passwordless OpenSSH Private Key authorized to login as `SSH_USER` on `REMOTE_HOST`
 ## @param data.knownHosts Used for OpenSSH HostKeyVerification. Output of `ssh-keyscan ${REMOTE_HOST}`.
-## @param data.existingSecret The name of a secret containing keys id_rsa and known_hosts.
+## @param data.existingSecret The name of a secret containing keys `id_rsa` and `known_hosts`.
 data:
   privateKey: ""
   knownHosts: ""

--- a/chart/ssh-punchhole/values.yaml
+++ b/chart/ssh-punchhole/values.yaml
@@ -57,6 +57,7 @@ configuration:
 ## @section SSH Credentials
 ## @param data.privateKey Passwordless OpenSSH Private Key authorized to login as `SSH_USER` on `REMOTE_HOST`
 ## @param data.knownHosts Used for OpenSSH HostKeyVerification. Output of `ssh-keyscan ${REMOTE_HOST}`.
+## @param data.existingSecret The name of a secret containing keys id_rsa and known_hosts.
 data:
   privateKey: ""
   knownHosts: ""


### PR DESCRIPTION
Hey, thanks for creating this awesome chart 😊

This PR adds an option for providing the ssh-data secret via an already existing one (`.Values.data.existingSecret`). If the option is not set, the chart will try to generate the secret (current behavior). This is especially useful, when one wants to use GitOps with encrypted secrets.
